### PR TITLE
fix (build): remove invalid import

### DIFF
--- a/src/clientapi/native/launchClient.js
+++ b/src/clientapi/native/launchClient.js
@@ -74,10 +74,6 @@ function analytics () {
 }
 
 function startApp (conn) {
-	if (conn) {
-		import ..debugging.TimestepInspector;
-		conn.addClient(new debugging.TimestepInspector());
-	}
 
 	var type = "Client";
 	//logging.setPrefix(type);


### PR DESCRIPTION
Builds try to import debugging.TimestepInspector and attach it to the
connection, but the file doesn't exist, causing a jsio import error
during the build step. This looks like an error, but doesn't actually
break the build.

This change does not restore the TimestepInspector, it just removes the
attempted import.
