### PR TITLE
fix (build): fix jsio import warning in builds

### DIFF
--- a/src/clientapi/native/launchClient.js
+++ b/src/clientapi/native/launchClient.js
@@ -14,7 +14,8 @@
  * along with the Game Closure SDK.  If not, see <http://mozilla.org/MPL/2.0/>.
  */
 
-GLOBAL.console = jsio('import base', {}).logging.get('console');
+var jsioBase = jsio('import base', {});
+GLOBAL.console = jsioBase.logging.get('console');
 
 if (!window.DEV_MODE) { window.DEV_MODE = false; }
 


### PR DESCRIPTION
js.io preprocessor was choking on the following line:
`GLOBAL.console = jsio('import base', {}).logging.get('console')`

Separating this into two lines enabled the jsio preprocessor to
correctly handle it.
