### PR TITLE
fix (js compiler): update to ecmascript5

### DIFF
--- a/src/build/common/jsCompiler.js
+++ b/src/build/common/jsCompiler.js
@@ -128,7 +128,8 @@ exports.JSCompiler = Class(function () {
 
     var closureOpts = [
       '--compilation_level', 'SIMPLE_OPTIMIZATIONS',
-      '--jscomp_off', 'internetExplorerChecks'
+      '--jscomp_off', 'internetExplorerChecks',
+      '--language_in', 'ECMASCRIPT5'
     ];
 
     this._api.jvmtools.exec({


### PR DESCRIPTION
Update the closure compiler flags to ecmascript5 (default is 3). This
fixes release builds failing from javascript that does not conform to
ecmascript3 but works otherwise.