### PR TITLE
add browser js/html to native-archive builds

### DIFF
--- a/src/build/native/native-archive.js
+++ b/src/build/native/native-archive.js
@@ -7,6 +7,10 @@ exports.opts = require('optimist')(process.argv)
                         .boolean('debug')
                         .default('debug', true)
 
+    .alias('browser', 'b').describe('browser', 'Include browser html/js')
+                        .boolean('browser')
+                        .default('browser', false)
+
     .alias('clean', 'c').describe('clean', 'Clean build before compilation')
                         .boolean('clean')
                         .default('clean', false);
@@ -22,6 +26,7 @@ exports.configure = function (api, app, config, cb) {
   config.repack = argv.repack;
   config.open = argv.open;
   config.reveal = argv.reveal;
+  config.archiveBrowserBuild = argv.browser;
   config.provisionPath = argv.provision;
   config.signingIdentity = argv.developer;
   config.enableLogging = !argv.debug && argv.enableReleaseLogging;
@@ -29,65 +34,96 @@ exports.configure = function (api, app, config, cb) {
   cb && cb();
 };
 
+// returns an archive with a patched finalize function that calls the original
+// finalize and then returns a Promise that resolves when the write stream
+// closes or rejects on errors
+function createArchive(archivePath) {
+  var archiver = require('archiver');
+  var archive = archiver.create('zip', {});
+  var fs = require('fs-extra');
+  var output = fs.createWriteStream(archivePath);
+  archive.pipe(output);
+
+  var onFinish = new Promise(function (resolve, reject) {
+    output.on('finish', resolve);
+    output.on('error', reject);
+    archive.on('error', reject);
+  });
+
+  var finalize = archive.finalize;
+  archive.finalize = function () {
+    finalize.apply(this, arguments);
+    return onFinish;
+  };
+
+  return archive;
+}
+
 // takes a app, subtarget(android/ios), additional opts.
 exports.build = function (api, app, config, cb) {
   logger = api.logging.get('build-native');
-  var outPath = config.outputResourcePath;
+
   var fs = require('fs-extra');
+  var glob = Promise.promisify(require('glob'));
+  var readFile = Promise.promisify(fs.readFile);
+  var stat = Promise.promisify(fs.stat);
+
+  var outPath = config.outputResourcePath;
   if (exports.opts.argv.clean) {
     fs.removeSync(outPath);
     fs.mkdirsSync(outPath);
   }
 
-  require('./resources').writeNativeResources(api, app, config, function (err) {
-    // do nothing if err
-    if (err) { return cb && cb(err); }
+  var archive;
+  var archiveName = app.manifest.shortName + '.zip';
 
-    // Find files in the output directory
-    var archiver = require('archiver');
-    var glob = Promise.promisify(require('glob'));
-    var readFile = Promise.promisify(fs.readFile);
-    var stat = Promise.promisify(fs.stat);
-    var archiveName = app.manifest.shortName + '.zip';
-    var archivePath = path.join(outPath, archiveName);
-
-    var archive = archiver.create('zip', {});
-    var output = fs.createWriteStream(archivePath);
-    archive.pipe(output);
-
-    var done = new Promise(function (resolve, reject) {
-      output.on('close', resolve);
-      archive.on('error', reject);
-    });
-
-    return glob(path.join(outPath, '**', '*'))
-      .call('sort', function(a, b) {
-        return a.localeCompare(b);
-      })
-      .each(function (file) {
-        var zipPath = file.replace(outPath + path.sep, '');
-        // Skip any existing archive file
-        if (zipPath === archiveName) {
-          return;
-        }
-
-        return stat(file)
-          .then(function (stats) {
-            if (stats.isDirectory()) {
-              archive.append(new Buffer(0), {name: zipPath + '/'});
-              return;
-            }
-
-            return readFile(file)
-              .then(function (buffer) {
-                archive.append(buffer, {name: zipPath});
-              });
+  require('./resources')
+    .writeNativeResources(api, app, config)
+    .then(function (buildResult) {
+      if (config.archiveBrowserBuild) {
+        var browserBuilder = require('../browser/');
+        config.target = 'browser-mobile';
+        return browserBuilder
+          .configure(api, app, config)
+          .then(function () {
+            config.spritesheets = buildResult.spritesheets;
+            return browserBuilder.build(api, app, config);
           });
-      })
-      .then(function () {
-        archive.finalize();
-        return done;
-      })
-      .nodeify(cb);
-  });
+      }
+    })
+    .then(function () {
+      var archivePath = path.join(outPath, archiveName);
+
+      archive = createArchive(archivePath);
+
+      // Find files in the output directory
+      return glob(path.join(outPath, '**', '*'));
+    })
+    .call('sort', function(a, b) {
+      return a.localeCompare(b);
+    })
+    .each(function (file) {
+      var zipPath = file.replace(outPath + path.sep, '');
+      // Skip any existing archive file
+      if (zipPath === archiveName) {
+        return;
+      }
+
+      return stat(file)
+        .then(function (stats) {
+          if (stats.isDirectory()) {
+            archive.append(new Buffer(0), {name: zipPath + '/'});
+            return;
+          }
+
+          return readFile(file)
+            .then(function (buffer) {
+              archive.append(buffer, {name: zipPath});
+            });
+        });
+    })
+    .then(function () {
+      return archive.finalize();
+    })
+    .nodeify(cb);
 };

--- a/src/build/native/resources.js
+++ b/src/build/native/resources.js
@@ -108,14 +108,21 @@ exports.writeNativeResources = function (api, app, config, cb) {
             contents: new Buffer(JSON.stringify(sourceMap))
           }));
 
-          logger.log('writing files to', config.outputResourcePath);
-          return new Promise(function (resolve, reject) {
-            streamFromArray.obj(files)
-              .pipe(vfs.dest(baseDirectory))
-              .on('end', resolve)
-              .on('error', reject);
-          });
+          return {
+            files: files,
+            spritesheets: spriterResult
+          };
         });
+    })
+    .tap(function writeFiles(buildResult) {
+      logger.log('writing', buildResult.files.length, 'files to', config.outputResourcePath);
+      return new Promise(function (resolve, reject) {
+        streamFromArray.obj(buildResult.files)
+          .pipe(vfs.dest(baseDirectory))
+          .on('end', resolve)
+          .on('error', function (e) { console.error(e); })
+          .on('error', reject);
+      });
     })
     .nodeify(cb);
 };


### PR DESCRIPTION
 - browser will not resprite if config.spritesheets is provided
 - adds a browser-mobile build to the native-archive build if `--browser` is
   provided