### PR TITLE
Fix for issue #261 - Support for windows format paths in global cache

### DIFF
--- a/src/clientapi/index.js
+++ b/src/clientapi/index.js
@@ -129,7 +129,8 @@ exports.ClientAPI = Class(lib.PubSub, function () {
   var spritesheets;
   try {
     if (GLOBAL.CACHE) {
-      spritesheets = JSON.parse(GLOBAL.CACHE['spritesheets/map.json']);
+      var spriteSheetCache = GLOBAL.CACHE['spritesheets/map.json'] || GLOBAL.CACHE['spritesheets\\map.json'];
+      spritesheets = JSON.parse(spriteSheetCache);
     }
   } catch (e) {
     logger.warn("spritesheet map failed to parse", e);
@@ -138,7 +139,8 @@ exports.ClientAPI = Class(lib.PubSub, function () {
   var soundMap;
   try {
     if (GLOBAL.CACHE) {
-      soundMap = JSON.parse(GLOBAL.CACHE['resources/sound-map.json']);
+      var soundMapCache = GLOBAL.CACHE['resources/sound-map.json'] || GLOBAL.CACHE['resources\\sound-map.json'];
+      soundMap = JSON.parse(soundMapCache);
     }
   } catch (e) {
     logger.warn("sound map failed to parse", e);


### PR DESCRIPTION
With regards to [#261](https://github.com/gameclosure/devkit/issues/261), node on windows is using back-slashes instead of forward-slashes when outputting file paths for the inline-cache.  I explored applying a transform directly on the output after it had been stringified, but that seemed more risky than resolving on the client side (with default for *nix style forward-slashes) since there appear to be only 2 places the inline cache are retrieved there.
