### PR TITLE
[TaskQueue] Reduce parallelization of tasks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,10 @@
 machine:
   xcode:
     version: "7.0"
-  environment:
-    XCODE_SCHEME: none
-    XCODE_PROJECT: none
 
 dependencies:
   pre:
-    - brew install node
+    - brew install node@6
     - |
       if [ ! -d /usr/local/Cellar/android-sdk/ ]; then
         brew install android-sdk

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     - brew install node@6
     - |
       if [ ! -d /usr/local/Cellar/android-sdk/ ]; then
-        brew install android-sdk
+        brew install Caskroom/cask/android-sdk
         echo 'y' | android update sdk --no-ui --force --all --filter platform-tools,android-19,build-tools-20.0.0
       else
         brew link android-sdk

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "archiver": "^0.14.4",
     "bluebird": "^3.4.7",
     "chalk": "^1.1.1",
-    "devkit-spriter": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+    "devkit-spriter": "git+https://github.com/bjornstar/devkit-spriter.git#serial-load",
     "fs-extra": "^0.23.1",
     "glob": "^5.0.2",
     "graceful-fs": "^4.1.2",

--- a/src/build/task-queue/index.js
+++ b/src/build/task-queue/index.js
@@ -8,7 +8,7 @@ const chalk = require('chalk');
 const log = debug('devkit-core:build:task-queue');
 
 
-var DEFAULT_NUM_WORKERS = require('os').cpus().length;
+var DEFAULT_NUM_WORKERS = 1;
 var DEFAULT_TASKS_PER_WORKER = 1;
 
 exports.TaskQueue = TaskQueue;


### PR DESCRIPTION
Running the tasks in parallel causes too much memory utilization on machines with more cores than memory.

Short term fix to get builds working again. I suggest removing `TaskQueue` and using `devkit-spriter` directly.
