### PR TITLE
Timestep webgl pipeline optim

### DIFF
--- a/timestep/src/platforms/browser/Context2D.js
+++ b/timestep/src/platforms/browser/Context2D.js
@@ -38,13 +38,20 @@ exports = function (opts) {
     return el;
   };
 
-  Object.defineProperty(ctx, 'filter', {
-    get: function() { return this._filter; },
-    set: function(value) { this._filter = value; }
+  ctx.__needsUpload = true;
+  ctx.texture = null;
+  Object.defineProperty(ctx, 'needsUpload', {
+    get: function() { return this.__needsUpload; },
+    set: function(value) { this.__needsUpload = value; }
   });
 
   ctx.reset = function () {
   };
+
+  Object.defineProperty(ctx, 'filter', {
+    get: function() { return this._filter; },
+    set: function(value) { this._filter = value; }
+  });
 
   ctx.clear = function () {
     this.save();

--- a/timestep/src/platforms/browser/webgl/WebGLContext2D.js
+++ b/timestep/src/platforms/browser/webgl/WebGLContext2D.js
@@ -415,29 +415,6 @@ class GLManager {
       gl.drawElements(gl.TRIANGLES, (next - start) * 6, gl.UNSIGNED_SHORT, start * 12);
     }
 
-  // setActiveRenderMode (id) {
-  //   if (this._activeRenderMode === id) {
-  //     return;
-  //   }
-
-  //   var ctx = this._activeCtx;
-  //   this._activeRenderMode = id;
-  //   var shader = this.shaders[id];
-
-  //   if (this._activeShader && this._activeShader !== shader) {
-  //     this._activeShader.disableVertexAttribArrays();
-  //   }
-
-  //   this._activeShader = shader;
-  //   var gl = this.gl;
-  //   gl.useProgram(shader.program);
-  //   shader.enableVertexAttribArrays();
-  //   gl.uniform2f(shader.uniforms.uResolution, ctx.width, ctx.height);
-  //   if (shader.uniforms.uSampler !== -1) {
-  //     gl.uniform1i(shader.uniforms.uSampler, 0);
-  //   }
-  // }
-
     this._drawIndex = -1;
     this._batchIndex = -1;
   }

--- a/timestep/src/platforms/browser/webgl/WebGLContext2D.js
+++ b/timestep/src/platforms/browser/webgl/WebGLContext2D.js
@@ -1,5 +1,3 @@
-let exports = {};
-
 /**
  * @license
  * This file is part of the Game Closure SDK.
@@ -28,13 +26,11 @@ import {
 
 import device from 'device';
 
-import loader from 'ui/resource/loader';
 import Color from 'ui/Color';
 import TextManager from './TextManager';
 import Shaders from './Shaders';
 import Matrix2D from './Matrix2D';
 import WebGLTextureManager from './WebGLTextureManager';
-
 
 
 class ContextStateStack {
@@ -170,7 +166,7 @@ class GLManager {
     this._indexCache = new Uint16Array(MAX_BATCH_SIZE * 6);
     this._vertexCache = new ArrayBuffer(MAX_BATCH_SIZE * STRIDE * 4);
     this._vertices = new Float32Array(this._vertexCache);
-    this._colors = new Uint8Array(this._vertexCache);
+    this._colors = new Uint32Array(this._vertexCache);
 
     var indexCount = MAX_BATCH_SIZE * 6;
     for (var i = 0, j = 0; i < indexCount; i += 6, j += 4) {
@@ -186,7 +182,7 @@ class GLManager {
 
     for (var i = 0; i <= MAX_BATCH_SIZE; i++) {
       this._batchQueue[i] = {
-        textureId: 0,
+        texture: null,
         index: 0,
         clip: false,
         filter: null,
@@ -204,10 +200,6 @@ class GLManager {
     this.initGL();
     this._primaryContext = new Context2D(this, this._canvas);
     this.activate(this._primaryContext);
-
-    loader.on(loader.IMAGE_LOADED, function (image) {
-      this.createOrUpdateTexture(image, image.__GL_ID, true);
-    }.bind(this));
 
     this.contextActive = true;
 
@@ -300,29 +292,6 @@ class GLManager {
     return ctx;
   }
 
-  setActiveRenderMode (id) {
-    if (this._activeRenderMode === id || !this.gl) {
-      return;
-    }
-
-    var ctx = this._activeCtx;
-    this._activeRenderMode = id;
-    var shader = this.shaders[id];
-
-    if (this._activeShader && this._activeShader !== shader) {
-      this._activeShader.disableVertexAttribArrays();
-    }
-
-    this._activeShader = shader;
-    var gl = this.gl;
-    gl.useProgram(shader.program);
-    shader.enableVertexAttribArrays();
-    gl.uniform2f(shader.uniforms.uResolution, ctx.width, ctx.height);
-    if (shader.uniforms.uSampler !== -1) {
-      gl.uniform1i(shader.uniforms.uSampler, 0);
-    }
-  }
-
   setActiveCompositeOperation (op) {
     op = op || 'source-over';
     if (this._activeCompositeOperation === op || !this.gl) {
@@ -395,7 +364,7 @@ class GLManager {
   }
 
   flush () {
-    if (this._batchIndex === -1 || !this.gl) {
+    if (this._batchIndex === -1) {
       return;
     }
 
@@ -411,63 +380,77 @@ class GLManager {
       } else {
         this.disableScissor();
       }
-      var textureId = curQueueObj.textureId;
-      if (textureId !== -1) {
-        var texture = this.textureManager.getTexture(textureId);
-        if (!texture) {
-          continue;
-        }
+      var texture = curQueueObj.texture;
+      if (texture) {
         gl.bindTexture(gl.TEXTURE_2D, texture);
       }
+
       this.setActiveCompositeOperation(curQueueObj.globalCompositeOperation);
-      this.setActiveRenderMode(curQueueObj.renderMode);
+
+      var renderMode = curQueueObj.renderMode;
+      if (renderMode !== this._activeRenderMode) {
+        var shader = this.shaders[renderMode];
+
+        var a; // attribute index
+        var lastAttributesOld = this._activeShader ? this._activeShader.lastAttributeIndex : -1;
+        var lastAttributesNew = shader.lastAttributeIndex;
+        if (lastAttributesOld > lastAttributesNew) {
+          for (a = lastAttributesOld; a > lastAttributesNew; a -= 1) {
+            gl.disableVertexAttribArray(a);
+          }
+        } else if (lastAttributesOld < lastAttributesNew) {
+          for (a = lastAttributesOld + 1; a <= lastAttributesNew; a += 1) {
+            gl.enableVertexAttribArray(a);
+          }
+        }
+
+        shader.useProgram(this._activeCtx);
+
+        this._activeShader = shader;
+        this._activeRenderMode = renderMode;
+      }
+
       var start = curQueueObj.index;
       var next = this._batchQueue[i + 1].index;
       gl.drawElements(gl.TRIANGLES, (next - start) * 6, gl.UNSIGNED_SHORT, start * 12);
     }
 
+  // setActiveRenderMode (id) {
+  //   if (this._activeRenderMode === id) {
+  //     return;
+  //   }
+
+  //   var ctx = this._activeCtx;
+  //   this._activeRenderMode = id;
+  //   var shader = this.shaders[id];
+
+  //   if (this._activeShader && this._activeShader !== shader) {
+  //     this._activeShader.disableVertexAttribArrays();
+  //   }
+
+  //   this._activeShader = shader;
+  //   var gl = this.gl;
+  //   gl.useProgram(shader.program);
+  //   shader.enableVertexAttribArrays();
+  //   gl.uniform2f(shader.uniforms.uResolution, ctx.width, ctx.height);
+  //   if (shader.uniforms.uSampler !== -1) {
+  //     gl.uniform1i(shader.uniforms.uSampler, 0);
+  //   }
+  // }
+
     this._drawIndex = -1;
     this._batchIndex = -1;
   }
 
-  createOrUpdateTexture (image, id, drawImmediately) {
-    var gl = this.gl;
-
-    if (!gl) {
-      return -1;
-    }
-
-    id = this.textureManager.createOrUpdateTexture(image, id);
-
-    if (drawImmediately) {
-      var currentAlpha = this._primaryContext.globalAlpha;
-      // Draw single, transparent pixel of image to ensure upload to buffer
-      this._primaryContext.globalAlpha = 0.00001;
-      this._primaryContext.drawImage(image, 0, 0, 1, 1, 0, 0, 1, 1);
-      this.flush();
-      this._primaryContext.globalAlpha = currentAlpha;
-    }
-
-    return id;
+  createTexture (image) {
+    return this.textureManager.createTexture(image);
   }
 
-  getTexture (id) {
-    return this.textureManager.getTexture(id);
-  }
-
-  deleteTexture (id) {
-    this.textureManager.deleteTexture(id);
-  }
-
-  deleteTextureForImage (image) {
-    this.textureManager.deleteTextureForImage(image);
+  deleteTexture (image) {
+    this.textureManager.deleteTexture(image);
   }
 
   enableScissor (x, y, width, height) {
-    if (!this.gl) {
-      return;
-    }
-
     var gl = this.gl;
     if (!this._scissorEnabled) {
       gl.enable(gl.SCISSOR_TEST);
@@ -486,10 +469,6 @@ class GLManager {
   }
 
   disableScissor () {
-    if (!this.gl) {
-      return;
-    }
-
     if (this._scissorEnabled) {
       var gl = this.gl;
       this._scissorEnabled = false;
@@ -497,7 +476,7 @@ class GLManager {
     }
   }
 
-  addToBatch (state, textureId) {
+  addToBatch (state, texture) {
     if (this._drawIndex >= MAX_BATCH_SIZE - 1) {
       this.flush();
     }
@@ -511,8 +490,8 @@ class GLManager {
       ? this._batchQueue[this._batchIndex]
       : null;
     var stateChanged = !queuedState
-      || queuedState.textureId !== textureId
-      || textureId === -1 && queuedState.fillStyle !== state.fillStyle
+      || queuedState.texture !== texture
+      || !texture && queuedState.fillStyle !== state.fillStyle
       || queuedState.globalCompositeOperation !== state.globalCompositeOperation
       || queuedState.filter !== filter || queuedState.clip !== clip
       || queuedState.clipRect.x !== clipRect.x
@@ -522,7 +501,7 @@ class GLManager {
 
     if (stateChanged) {
       var queueObject = this._batchQueue[++this._batchIndex];
-      queueObject.textureId = textureId;
+      queueObject.texture = texture;
       queueObject.index = this._drawIndex;
       queueObject.globalCompositeOperation = state.globalCompositeOperation;
       queueObject.filter = filter;
@@ -532,7 +511,7 @@ class GLManager {
       queueObject.clipRect.width = clipRect.width;
       queueObject.clipRect.height = clipRect.height;
 
-      if (textureId === -1) {
+      if (!texture) {
         queueObject.renderMode = RENDER_MODES.Rect;
       } else if (filter) {
         queueObject.renderMode = RENDER_MODES[filter.getType()];
@@ -550,21 +529,19 @@ class GLManager {
   }
 
   activate (ctx, forceActivate) {
-    var gl = this.gl;
     var sameContext = ctx === this._activeCtx;
-
     if (sameContext && !forceActivate) {
       return;
     }
 
     if (!sameContext) {
       this.flush();
-      gl.finish();
+      this.gl.finish();
       this._activeCtx = ctx;
     }
 
-    gl.bindFramebuffer(gl.FRAMEBUFFER, ctx.frameBuffer);
-    gl.viewport(0, 0, ctx.width, ctx.height);
+    this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, ctx.frameBuffer);
+    this.gl.viewport(0, 0, ctx.width, ctx.height);
     this._activeRenderMode = -1;
   }
 }
@@ -593,17 +570,13 @@ class Context2D {
     this.font = '11px ' + device.defaultFontFamily;
     this.frameBuffer = null;
     this.filter = null;
+    this.isWebGL = true;
   }
 
   createOffscreenFrameBuffer () {
     var gl = this._manager.gl;
-    if (!gl) {
-      return;
-    }
-
     var activeCtx = this._manager._activeCtx;
-    var id = this._manager.createOrUpdateTexture(this.canvas);
-    this._texture = this._manager.getTexture(id);
+    this._texture = this._manager.createTexture(this.canvas);
     this.frameBuffer = gl.createFramebuffer();
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.frameBuffer);
     gl.bindTexture(gl.TEXTURE_2D, this._texture);
@@ -766,9 +739,6 @@ class Context2D {
   roundRect (x, y, width, height, radius) {}
 
   fillText (text, x, y) {
-    if (!this._manager.gl) {
-      return;
-    }
     var textData = this._manager.textManager.get(this, text, false);
     if (!textData) {
       return;
@@ -779,9 +749,6 @@ class Context2D {
   }
 
   strokeText (text, x, y) {
-    if (!this._manager.gl) {
-      return;
-    }
     var textData = this._manager.textManager.get(this, text, true);
     if (!textData) {
       return;
@@ -797,15 +764,10 @@ class Context2D {
   }
 
   drawImage (image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight) {
-    if (!this._manager.gl) {
-      return;
-    }
-
     if (!image) {
       return;
     }
 
-    var flip = !!image.__glFlip;
     var state = this.stack.state;
     var alpha = state.globalAlpha;
     if (alpha === 0) {
@@ -815,17 +777,13 @@ class Context2D {
     var manager = this._manager;
     manager.activate(this);
 
-    var glId = image.__GL_ID;
-    if (glId === undefined || image.__needsUpload) {
-      // Invalid image? Early out if so.
-      if (image.width === 0 || image.height === 0 || !image.complete) {
-        return;
-      }
+    if (image.__needsUpload) {
+      manager.deleteTexture(image);
+      image.texture = manager.createTexture(image);
       image.__needsUpload = false;
-      glId = manager.createOrUpdateTexture(image, glId);
     }
 
-    var drawIndex = manager.addToBatch(this.stack.state, glId);
+    var drawIndex = manager.addToBatch(this.stack.state, image.texture);
     var width = this.width;
     var height = this.height;
     var imageWidth = image.width;
@@ -835,34 +793,6 @@ class Context2D {
     var syH = sy + sHeight;
     var dxW = dx + dWidth;
     var dyH = dy + dHeight;
-
-    if (flip) {
-      sy = imageHeight - sy;
-      syH = sy - sHeight;
-    }
-
-    var needsTrim = sx < 0 || sxW > imageWidth || sy < 0 || syH > imageHeight;
-
-    if (needsTrim) {
-      var newSX = max(0, sx);
-      var newSY = max(0, sy);
-      var newSXW = min(sxW, imageWidth);
-      var newSYH = min(syH, imageHeight);
-      var scaleX = dWidth / sWidth;
-      var scaleY = dHeight / sHeight;
-      var trimLeft = (newSX - sx) * scaleX;
-      var trimRight = (sxW - newSXW) * scaleX;
-      var trimTop = (newSY - sy) * scaleY;
-      var trimBottom = (syH - newSYH) * scaleY;
-      dx += trimLeft;
-      dxW -= trimRight;
-      dy += trimTop;
-      dyH -= trimBottom;
-      sx = newSX;
-      sy = newSY;
-      sxW = newSXW;
-      syH = newSYH;
-    }
 
     // Calculate 4 vertex positions
     var x0 = dx * m.a + dy * m.c + m.tx;
@@ -919,15 +849,9 @@ class Context2D {
 
     if (state.filter) {
       var color = state.filter.get();
-      var ci = drawIndex * 4 * STRIDE;
       var cc = manager._colors;
-      cc[ci + 20] = cc[ci + 44] = cc[ci + 68] = cc[ci + 92] = color.r;
-      // R
-      cc[ci + 21] = cc[ci + 45] = cc[ci + 69] = cc[ci + 93] = color.g;
-      // G
-      cc[ci + 22] = cc[ci + 46] = cc[ci + 70] = cc[ci + 94] = color.b;
-      // B
-      cc[ci + 23] = cc[ci + 47] = cc[ci + 71] = cc[ci + 95] = color.a * 255;
+      var packedColor = (color.r & 0xff) + ((color.g & 0xff) << 8) + ((color.b & 0xff) << 16) + (((color.a * 255) & 0xff) << 24);
+      cc[i + 5] = cc[i + 11] = cc[i + 17] = cc[i + 23] = packedColor;
     }
   }
 
@@ -966,7 +890,7 @@ class Context2D {
 
     var manager = this._manager;
     manager.activate(this);
-    var drawIndex = manager.addToBatch(this.stack.state, -1);
+    var drawIndex = manager.addToBatch(this.stack.state, null);
 
     // TODO: remove private access to _vertices
     var vc = manager._vertices;
@@ -988,19 +912,13 @@ class Context2D {
     vc[i + 19] = y3;
     vc[i + 22] = this.globalAlpha;
 
-    var ci = drawIndex * 4 * STRIDE;
     var cc = manager._colors;
-    cc[ci + 20] = cc[ci + 44] = cc[ci + 68] = cc[ci + 92] = color.r;
-    // R
-    cc[ci + 21] = cc[ci + 45] = cc[ci + 69] = cc[ci + 93] = color.g;
-    // G
-    cc[ci + 22] = cc[ci + 46] = cc[ci + 70] = cc[ci + 94] = color.b;
-    // B
-    cc[ci + 23] = cc[ci + 47] = cc[ci + 71] = cc[ci + 95] = color.a * 255;
+    var packedColor = (color.r & 0xff) + ((color.g & 0xff) << 8) + ((color.b & 0xff) << 16) + (((color.a * 255) & 0xff) << 24);
+    cc[i + 5] = cc[i + 11] = cc[i + 17] = cc[i + 23] = packedColor;
   }
 
-  deleteTextureForImage (canvas) {
-    this._manager.deleteTextureForImage(canvas);
+  deleteTexture (image) {
+    this._manager.deleteTexture(image);
   }
 }
 
@@ -1030,6 +948,5 @@ for (var i = 0; i < contextProperties.length; i++) {
   createContextProperty(Context2D.prototype, contextProperties[i]);
 }
 
-exports = new GLManager();
-
-export default exports;
+var glManager = new GLManager();
+export default glManager;

--- a/timestep/src/platforms/browser/webgl/WebGLTextureManager.js
+++ b/timestep/src/platforms/browser/webgl/WebGLTextureManager.js
@@ -40,7 +40,6 @@ export default class WebGLTextureManager extends PubSub {
   }
 
   deleteTextureForImage (image) {
-    console.error('deleteTextureForImage', image)
     var texture = image.texture;
     if (texture) {
       this.deleteTexture(texture);

--- a/timestep/src/platforms/browser/webgl/WebGLTextureManager.js
+++ b/timestep/src/platforms/browser/webgl/WebGLTextureManager.js
@@ -39,101 +39,44 @@ export default class WebGLTextureManager extends PubSub {
     this.reloadTextures();
   }
 
-  getTexture (id) {
-    var textureData = this.textureDataCache.get(id);
-    return textureData
-      ? textureData.texture
-      : null;
-  }
-
-  getTextureData (id) {
-    var textureData = this.textureDataCache.get(id);
-    return textureData || null;
-  }
-
   deleteTextureForImage (image) {
-    if (image.__GL_ID !== undefined) {
-      this.deleteTexture(image.__GL_ID);
+    console.error('deleteTextureForImage', image)
+    var texture = image.texture;
+    if (texture) {
+      this.deleteTexture(texture);
     }
   }
 
-  deleteTexture (id) {
+  deleteTexture (textureData) {
     this.emit(WebGLTextureManager.TEXTURE_REMOVED);
-    var textureData = this.textureDataCache.remove(id);
     if (textureData) {
       this.gl.deleteTexture(textureData.texture);
-      this.removeFromByteCount(textureData.width, textureData.height);
-      textureData.image.__GL_ID = undefined;
     }
   }
 
-  createOrUpdateTexture (image, id) {
-    var gl = this.gl;
-    if (!gl) {
-      return -1;
-    }
-
+  createTexture (image) {
     var width = image.width;
     var height = image.height;
-
-    if (!image.dispose) {
-      image.dispose = bind(this, function () {
-        this.deleteTextureForImage(image);
-      });
-    }
 
     if (width === 0 || height === 0) {
       throw new Error('Image cannot have a width or height of 0.');
     }
 
-    if (id === undefined) {
-      id = image.__GL_ID !== undefined
-        ? image.__GL_ID
-        : CACHE_UID++;
-    }
+    var gl = this.gl;
+    var texture = gl.createTexture();
+    var textureData = {
+      image: image,
+      isImg: image instanceof Image,
+      isCanvas: image instanceof HTMLCanvasElement,
+      width: width,
+      height: height,
+      texture: texture
+    };
 
-    image.__GL_ID = id;
-
-    var textureDataEntry = this.textureDataCache.find(id);
-    var textureData = textureDataEntry
-      ? textureDataEntry.value
-      : null;
-    var needsAddByteCount = false;
-
-    // No data exists for id, create new entry
-    if (!textureData) {
-      textureData = {
-        image: image,
-        isImg: image instanceof Image,
-        isCanvas: image instanceof HTMLCanvasElement,
-        width: width,
-        height: height,
-        texture: gl.createTexture()
-      };
-
-      gl.bindTexture(gl.TEXTURE_2D, textureData.texture);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-      this.textureDataCache.put(id, textureData);
-      needsAddByteCount = true;
-    } else {
-      gl.bindTexture(gl.TEXTURE_2D, textureData.texture);
-    }
-
-    if (textureData.width !== width || textureData.height !== height) {
-      this.removeFromByteCount(textureData.width, textureData.height);
-      textureData.width = width;
-      textureData.height = height;
-      needsAddByteCount = true;
-    }
-
-    if (textureData.image !== image) {
-      textureData.image.__GL_ID = undefined;
-      textureData.image = image;
-      textureData.isImg = image instanceof Image;
-      textureData.isCanvas = image instanceof HTMLCanvasElement;
-    }
+    gl.bindTexture(gl.TEXTURE_2D, textureData.texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
     if (textureData.isImg || textureData.isCanvas) {
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
@@ -141,11 +84,11 @@ export default class WebGLTextureManager extends PubSub {
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
     }
 
-    if (needsAddByteCount) {
-      this.addToByteCount(width, height);
-    }
+    var cacheKey = CACHE_UID++;
+    this.textureDataCache.put(cacheKey, textureData);
+    this.addToByteCount(width, height);
 
-    return id;
+    return texture;
   }
 
   reloadTextures () {
@@ -177,7 +120,9 @@ export default class WebGLTextureManager extends PubSub {
           this.textureDataCache.get(oldestTextureEntry.key);
           continue;
         }
-        this.deleteTexture(oldestTextureEntry.key);
+        var textureData = oldestTextureEntry.value;
+        this.deleteTexture(textureData.texture);
+        this.removeFromByteCount(textureData.width, textureData.height);
       }
     }
   }

--- a/timestep/src/ui/Engine.js
+++ b/timestep/src/ui/Engine.js
@@ -70,6 +70,36 @@ timer.onTick = function (dt) {
   }
 };
 
+// var interval = 5000;
+// var timePerFrame = 0;
+// var sampleIdx = 0;
+// setInterval(function() {
+//   sampleIdx += 1;
+//   var entries = window.performance.getEntriesByName('timePerFrame');
+//   var total = 0;
+//   var nbSamples = interval * 60 / 1000;
+//   var start = Math.max(0, entries.length - nbSamples);
+//   for (var i = start; i < entries.length; i += 1) {
+//     total += entries[i].duration;
+//   }
+//   timePerFrame = total / (entries.length - start);
+//   var log = '* sample after ' + (sampleIdx * interval / 1000) + 's';
+//   log += '  ms/frame = ' + timePerFrame.toFixed(2);
+//   console.error(log);
+// }, interval);
+
+// var _timers = [];
+// timer.onTick = function (dt) {
+// performance.mark('start');
+//   var i = _timers.length;
+//   while (i--) {
+//     _timers[i](dt);
+//   }
+// performance.mark('end');
+// performance.measure('timePerFrame', 'start', 'end');
+// };
+
+
 var __instance = null;
 
 /**

--- a/timestep/src/ui/Engine.js
+++ b/timestep/src/ui/Engine.js
@@ -70,36 +70,6 @@ timer.onTick = function (dt) {
   }
 };
 
-// var interval = 5000;
-// var timePerFrame = 0;
-// var sampleIdx = 0;
-// setInterval(function() {
-//   sampleIdx += 1;
-//   var entries = window.performance.getEntriesByName('timePerFrame');
-//   var total = 0;
-//   var nbSamples = interval * 60 / 1000;
-//   var start = Math.max(0, entries.length - nbSamples);
-//   for (var i = start; i < entries.length; i += 1) {
-//     total += entries[i].duration;
-//   }
-//   timePerFrame = total / (entries.length - start);
-//   var log = '* sample after ' + (sampleIdx * interval / 1000) + 's';
-//   log += '  ms/frame = ' + timePerFrame.toFixed(2);
-//   console.error(log);
-// }, interval);
-
-// var _timers = [];
-// timer.onTick = function (dt) {
-// performance.mark('start');
-//   var i = _timers.length;
-//   while (i--) {
-//     _timers[i](dt);
-//   }
-// performance.mark('end');
-// performance.measure('timePerFrame', 'start', 'end');
-// };
-
-
 var __instance = null;
 
 /**

--- a/timestep/src/ui/resource/Image.js
+++ b/timestep/src/ui/resource/Image.js
@@ -80,6 +80,7 @@ export default class ImageWrapper extends PubSub {
 
     resourceLoader._updateImageMap(this._map, opts.url, opts.sourceX, opts.sourceY,
       opts.sourceW, opts.sourceH);
+    this._onMapUpdate();
 
     // srcImage can be null, then setSrcImg will create one
     // (use the map's URL in case it was updated to a spritesheet)
@@ -144,6 +145,26 @@ export default class ImageWrapper extends PubSub {
     }
   }
 
+  _onMapUpdate () {
+    var map = this._map;
+    this._x = map.x;
+    this._y = map.y;
+    this._width = map.width;
+    this._height = map.height;
+
+    var marginLeft = map.marginLeft;
+    var marginTop = map.marginTop;
+
+    var xRatio = 1 / (marginLeft + this._width + map.marginRight);
+    var yRatio = 1 / (marginTop + this._height + map.marginBottom);
+
+    this._marginLeftRatio = marginLeft * xRatio;
+    this._marginRightRatio = marginTop * yRatio;
+
+    this._widthRatio = this._width * xRatio;
+    this._heightRatio = this._height * yRatio;
+  }
+
   getURL () {
     return this._map.url;
   }
@@ -170,27 +191,35 @@ export default class ImageWrapper extends PubSub {
   }
   setSourceX (x) {
     this._map.x = x;
+    this._onMapUpdate();
   }
   setSourceY (y) {
     this._map.y = y;
+    this._onMapUpdate();
   }
   setSourceW (w) {
     this._map.width = w;
+    this._onMapUpdate();
   }
   setSourceH (h) {
     this._map.height = h;
+    this._onMapUpdate();
   }
   setMarginTop (n) {
     this._map.marginTop = n;
+    this._onMapUpdate();
   }
   setMarginRight (n) {
     this._map.marginRight = n;
+    this._onMapUpdate();
   }
   setMarginBottom (n) {
     this._map.marginBottom = n;
+    this._onMapUpdate();
   }
   setMarginLeft (n) {
     this._map.marginLeft = n;
+    this._onMapUpdate();
   }
   setURL (url) {
     resourceLoader._updateImageMap(this._map, url);
@@ -219,6 +248,7 @@ export default class ImageWrapper extends PubSub {
     map.marginRight = marginRight || 0;
     map.marginBottom = marginBottom || 0;
     map.marginLeft = marginLeft || 0;
+    this._onMapUpdate();
     this.emit('changeBounds');
   }
   doOnLoad () {
@@ -268,6 +298,7 @@ export default class ImageWrapper extends PubSub {
     }
 
     map.url = image.src;
+    this._onMapUpdate();
     this._cb.fire(null, this);
   }
   isError () {
@@ -281,21 +312,12 @@ export default class ImageWrapper extends PubSub {
    * Easy-to-use 5 param render function that relies on the internal _map
    */
   renderShort (ctx, destX, destY, destW, destH) {
-    if (!this.isReady()) { return; }
+    destX += destW * this._marginLeftRatio;
+    destY += destH * this._marginRightRatio;
+    destW *= this._widthRatio;
+    destH *= this._heightRatio;
 
-    var map = this._map;
-    var srcX = map.x;
-    var srcY = map.y;
-    var srcW = map.width;
-    var srcH = map.height;
-    var scaleX = destW / (map.marginLeft + srcW + map.marginRight);
-    var scaleY = destH / (map.marginTop + srcH + map.marginBottom);
-    destX += scaleX * map.marginLeft;
-    destY += scaleY * map.marginTop;
-    destW = scaleX * srcW;
-    destH = scaleY * srcH;
-
-    this.render(ctx, srcX, srcY, srcW, srcH, destX, destY, destW, destH);
+    this.render(ctx, this._x, this._y, this._width, this._height, destX, destY, destW, destH);
   }
 
   /**
@@ -304,7 +326,7 @@ export default class ImageWrapper extends PubSub {
   render (ctx, srcX, srcY, srcW, srcH, destX, destY, destW, destH) {
     if (!this.isReady()) { return; }
 
-    var srcImg = this._srcImg;
+    var srcImg = ctx.isWebGL ? this._srcImg : this._srcImg.image;
 
     if (ctx.filter) {
       var filterImg = filterRenderer.renderFilter(ctx, this, srcX, srcY, srcW, srcH);

--- a/timestep/src/ui/resource/loader.js
+++ b/timestep/src/ui/resource/loader.js
@@ -15,7 +15,6 @@
  */
 
 import i18n from './i18n';
-import Emitter from 'event/Emitter';
 import userAgent from 'userAgent';
 import loaders from 'ui/resource/primitiveLoaders';
 import { logger } from 'base';
@@ -73,14 +72,11 @@ var loadMethodsByExtension = {
   '.html': loadFile
 };
 
-class Loader extends Emitter {
+class Loader {
   constructor () {
-    super();
-
-    this._crossOrigin = undefined;
-
     this._user = null;
     this._password = null;
+    this._crossOrigin = undefined;
 
     this._map = {};
     this._originalMap = {};
@@ -466,7 +462,6 @@ class Loader extends Emitter {
 
 }
 
-Loader.prototype.IMAGE_LOADED = 'imageLoaded';
 Loader.prototype.PRIORITY_LOW = loaders.PRIORITY_LOW;
 Loader.prototype.PRIORITY_MEDIUM = loaders.PRIORITY_MEDIUM;
 // Loader.prototype.PRIORITY_HIGH = loaders.PRIORITY_HIGH;

--- a/timestep/src/ui/resource/primitiveLoaders.js
+++ b/timestep/src/ui/resource/primitiveLoaders.js
@@ -19,6 +19,8 @@ import audioContext from 'audioContext';
 
 // TODO: is this file where caches should be initialized and populated?
 import { CACHE, logger } from 'base';
+import WebGLContext2D from 'platforms/browser/webgl/WebGLContext2D';
+
 var FILE_CACHE = CACHE;
 
 var IMAGE_CACHE = {};
@@ -61,6 +63,18 @@ exports.PRIORITY_MEDIUM = PRIORITY_MEDIUM;
 var pendingRequests = [];
 var pendingRequestsLowPriority = [];
 var nbAssetsLoading = 0;
+
+var webglSupported = WebGLContext2D.isSupported;
+
+class TextureWrapper {
+  constructor (image, texture, width, height) {
+    this.image = image;
+    this.texture = texture;
+    this.width = width;
+    this.height = height;
+    this.__needsUpload = false;
+  }
+}
 
 function pendRequest (priority, request) {
   if (nbAssetsLoading === MAX_PARALLEL_LOADINGS) {
@@ -151,10 +165,15 @@ function _loadImage (url, cb, loader, priority, isExplicit) {
     this.onload  = null;
     this.onerror = null;
 
-    // emitting event
-    loader.emit(loader.IMAGE_LOADED, this, url);
+    var image;
+    if (webglSupported) {
+      var texture = WebGLContext2D.createTexture(this);
+      image = new TextureWrapper(this, texture, this.width, this.height);
+    } else {
+      image = this;
+    }
 
-    return onRequestComplete(cb, this);
+    return onRequestComplete(cb, image);
   };
 
   img.onerror = function (error) {


### PR DESCRIPTION
# Overview
Simplification and optimization of WebGL rendering pipeline. Mainly 3 objects were the focus of the otpimizations: the `flush` and `drawImage` methods and the `ContextStateStack` class in `WebGLContext2D`.

# Changes
- The `drawImage` method used to include several state checks on the image and WebGL context, they are now gone as they seem unnecessary. If they happened to be required, they should be added at a different place where they would execute only once and not every single frame.
- The `flush` method and associated methods in `Shader` are now doing program switching more efficiently.
- Textures are now wrapped into `TextureWrapper` objects that include a reference on the original image. The goal was to avoid unoptimizing images by sticking properties onto them.
- `ContextStateStack` has been removed as state properties of the context are now directly attached to the context, reducing the chain of property accesses.
- All the checks on the existence of the `gl` property were removed. WebGL context is initialized when the `WebGLContext2D` instance is created and there is no need to check if it was properly initialized in every method accessing the WebGL API.

# Performance
Overall there seems to be an obvious performance gain in terms of CPU usage.
As usual, the relative performance gain (5~20%) depends on the test, the device and measurement method.

## Chrome - MacBook pro
### Everwing - start menu - chrome profile
#### Before
<img width="400" alt="everwing-startmenu-heavy" src="https://user-images.githubusercontent.com/1897225/30098106-86bd0268-931b-11e7-8476-3e5237cd92af.png">

#### After
<img width="414" alt="everwing-startmenu-heavy" src="https://user-images.githubusercontent.com/1897225/30098090-76af065a-931b-11e7-89fa-4293d765f841.png">
The `drawImage`  and `flush` methods are now faster, The `set` method has disappeared. also the % used by the program is remain roughly identical, meaning that the performance boost is reflected in the program usage.

### Everwing - gameplay - chrome profile
#### Before
<img width="410" alt="everwing-gameplay-heavy" src="https://user-images.githubusercontent.com/1897225/30098159-c7dfeef4-931b-11e7-8fb0-bb6d5a17f628.png">

#### After
<img width="434" alt="everwing-gameplay-heavy" src="https://user-images.githubusercontent.com/1897225/30098177-d1e7a7a2-931b-11e7-9473-7e2a619fa015.png">
Here as well the `drawImage`, `flush` and `set` methods are optimized. % of program remain identical.

### Everwing - gameplay - chrome profile compilation
The following screenshots show the average non-idle CPU time profiled by chrome across 6 gameplay runs > 10s:
#### Before
<img width="154" alt="everwing-gameplay" src="https://user-images.githubusercontent.com/1897225/30098331-75d130a4-931c-11e7-9f56-2e5d94cbec00.png">

#### After
<img width="157" alt="everwing-gameplay" src="https://user-images.githubusercontent.com/1897225/30098327-72ebd948-931c-11e7-91ba-e8923b29f3d8.png">

On this benchmark the gain appears consequent: (13.8 - 11) / 13.8 = 20% boost!

### Everwing - gameplay - duration of engine tick method on chrome
#### Before
<img width="275" alt="everwing-startmenu-engine-tick" src="https://user-images.githubusercontent.com/1897225/30099697-778ad86e-9321-11e7-972a-9b132ae38cf6.png">

#### After
<img width="270" alt="everwing-startmenu-engine-tick" src="https://user-images.githubusercontent.com/1897225/30099701-7c9a16d0-9321-11e7-9976-3673d6921754.png">

Here as well the performance gain is obvious: (0.66 - 0.56) / 0.66 = 15%

## Chrome - iPhone 7
### Everwing - start menu - safari profile
#### Before
<img width="490" alt="everwing-startmenu-iphone7" src="https://user-images.githubusercontent.com/1897225/30100180-effe6170-9322-11e7-8965-d29ce7ff2f63.png">

#### After
<img width="453" alt="everwing-startmenu-iphone7" src="https://user-images.githubusercontent.com/1897225/30100193-f8ba4590-9322-11e7-91fc-33438e3811cd.png">

Just as an chrome, the `drawImage` and `set` methods have been optimized. For some reason the `flush` method never appeared (self time too insignificant). Overall benefit is not obvious on this profile as the idle time usually is hidden under the `drawElements` self time.
The optimized was possibly slow to kick in? It would seem so as subsequent profiles played in the favor of the changes.

### Everwing - start menu - safari profile
#### Before
<img width="456" alt="everwing-gameplay-iphone7" src="https://user-images.githubusercontent.com/1897225/30100989-afa4576c-9325-11e7-9629-8e25372b7dc9.png">

#### After
<img width="457" alt="everwing-gameplay-iphone7" src="https://user-images.githubusercontent.com/1897225/30100299-54bf4106-9323-11e7-8b98-2da1832a2ffc.png">

On this profile the performance boost is quite obvious (optimizer possibly played in favor of the changes) if we consider the idle time as being hidden in the `drawElements` self time: (32.6 - 24.1) / 32.6 = 26% boost

# Conclusion
Overall I think this work will provide a 10~15% cpu boost (even though some profiles seem to indicate a higher gain). Analytics will tell us but slowest devices should now run Everwing at 55fps. Meaning that we probably are 2 optimizations away from providing an average of 60fps on the slowest devices on Everwing (up from 30fps 3 months ago).