### PR TITLE
instead of creating a script tag, eval main source

### DIFF
--- a/src/clientapi/bootstrap.js
+++ b/src/clientapi/bootstrap.js
@@ -69,17 +69,13 @@ class DevkitClient {
     // };
 
     var buildURL = this._buildURL;
-    element.onerror = function (error) {
-      this.onload = null;
-      this.onerror = null;
-      var statusCode = ' Status code: ' + error.status;
-      var reason = ' Reason: ' + error.reason;
-      var response = ' Response: ' + error.response;
-      console.error('Build not found: ' + buildURL + statusCode + reason + response);
+    var xhr = new XMLHttpRequest();
+    xhr.onload = function (res) {
+      var src = this.responseText;
+      window.eval(src);
     };
-
-    element.src = buildURL;
-    document.getElementsByTagName('head')[0].appendChild(element);
+    xhr.open('GET', this._buildURL);
+    xhr.send();
   }
 };
 

--- a/src/clientapi/bootstrap.js
+++ b/src/clientapi/bootstrap.js
@@ -61,7 +61,6 @@ class DevkitClient {
   }
 
   _loadBuild () {
-    var element = document.createElement('script');
 
     // element.onload = function () {
     //   this.onload = null;
@@ -69,13 +68,31 @@ class DevkitClient {
     // };
 
     var buildURL = this._buildURL;
-    var xhr = new XMLHttpRequest();
-    xhr.onload = function (res) {
-      var src = this.responseText;
-      window.eval(src);
-    };
-    xhr.open('GET', this._buildURL);
-    xhr.send();
+    // these are not if/else because we want the dead code
+    // elimination to work nicely.
+    if (process.env.NODE_ENV == 'development') {
+      var element = document.createElement('script');
+      element.onerror = function (error) {
+        this.onload = null;
+        this.onerror = null;
+        var statusCode = ' Status code: ' + error.status;
+        var reason = ' Reason: ' + error.reason;
+        var response = ' Response: ' + error.response;
+        console.error('Build not found: ' + buildURL + statusCode + reason + response);
+      };
+
+      element.src = buildURL;
+      document.getElementsByTagName('head')[0].appendChild(element);
+    }
+    if (process.env.NODE_ENV == 'production') {
+      var xhr = new XMLHttpRequest();
+      xhr.onload = function (res) {
+        var src = this.responseText;
+        window.eval(src);
+      };
+      xhr.open('GET', this._buildURL);
+      xhr.send();
+    }
   }
 };
 


### PR DESCRIPTION
For production builds this keeps it from showing in the devtools.

For dev builds, we either need to figure out why webpack's sourcemaps
aren't working for the eval, or switch between script and eval on build
type.