### PR TITLE
Fix image loading issue

### DIFF
--- a/timestep/src/ui/resource/Image.js
+++ b/timestep/src/ui/resource/Image.js
@@ -101,7 +101,7 @@ export default class ImageWrapper extends PubSub {
         resourceLoader.setAssetCrossOrigin(url, this._crossOrigin);
       }
 
-      resourceLoader._loadImage(url, img => this._onLoad(img, loadRequestID));
+      resourceLoader.loadImage(url, img => this._onLoad(img, loadRequestID));
     }
   }
 


### PR DESCRIPTION
After upgrade to the minicore, FB avatars in flexible messages stopped work. I found that this is related to the `resourceLoader._loadImage` method. See demo: http://take.ms/dyYTk